### PR TITLE
Add design file processing and tech sheet generation

### DIFF
--- a/agent
+++ b/agent
@@ -12,3 +12,12 @@ functions:
       name:
         type: string
         description: Имя пользователя
+  - name: create_tech_sheets
+    description: Создает технические листы по дизайнерскому файлу
+    parameters:
+      file_path:
+        type: string
+        description: Путь к файлу дизайна (SVG или CDR)
+      spec:
+        type: object
+        description: Ожидаемые размеры объектов в формате словаря

--- a/design_processor.py
+++ b/design_processor.py
@@ -1,0 +1,105 @@
+"""Module for processing design files (SVG/CDR) and generating technical sheets."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+import xml.etree.ElementTree as ET
+
+
+@dataclass
+class DesignObject:
+    """Represents a graphical object with dimensions."""
+    id: str
+    type: str
+    width: float
+    height: float
+
+
+def extract_dimensions(file_path: str) -> List[DesignObject]:
+    """Extract objects and their dimensions from a design file.
+
+    Currently supports basic SVG files. CDR support is not implemented
+    and will raise :class:`NotImplementedError`.
+    """
+    if file_path.lower().endswith(".svg"):
+        return _extract_svg(file_path)
+    if file_path.lower().endswith(".cdr"):
+        raise NotImplementedError("CDR parsing is not implemented")
+    raise ValueError("Unsupported file type")
+
+
+def _extract_svg(file_path: str) -> List[DesignObject]:
+    tree = ET.parse(file_path)
+    root = tree.getroot()
+    ns = {"svg": "http://www.w3.org/2000/svg"}
+    objects: List[DesignObject] = []
+    # rectangles
+    for rect in root.findall(".//svg:rect", ns):
+        obj_id = rect.get("id", "rect")
+        width = float(rect.get("width", 0))
+        height = float(rect.get("height", 0))
+        objects.append(DesignObject(obj_id, "rect", width, height))
+    # circles – use diameter for width/height
+    for circle in root.findall(".//svg:circle", ns):
+        obj_id = circle.get("id", "circle")
+        r = float(circle.get("r", 0))
+        d = 2 * r
+        objects.append(DesignObject(obj_id, "circle", d, d))
+    return objects
+
+
+def verify_against_spec(
+    objects: List[DesignObject], spec: Dict[str, Dict[str, float]], *, tolerance: float = 1e-6
+) -> List[Dict[str, float]]:
+    """Check that extracted objects match the provided specification.
+
+    Parameters
+    ----------
+    objects: List[DesignObject]
+        Extracted objects.
+    spec: Dict[str, Dict[str, float]]
+        Mapping of object id to expected dimensions.
+    tolerance: float
+        Allowed absolute difference.
+
+    Returns
+    -------
+    List of mismatches. Each mismatch contains ``id``, ``field``,
+    ``expected`` and ``actual`` values.
+    """
+    mismatches: List[Dict[str, float]] = []
+    for obj in objects:
+        expected = spec.get(obj.id)
+        if not expected:
+            continue
+        for field in ("width", "height"):
+            exp_val = expected.get(field)
+            if exp_val is None:
+                continue
+            act_val = getattr(obj, field)
+            if abs(act_val - exp_val) > tolerance:
+                mismatches.append(
+                    {
+                        "id": obj.id,
+                        "field": field,
+                        "expected": exp_val,
+                        "actual": act_val,
+                    }
+                )
+    return mismatches
+
+
+def generate_client_sheet(objects: List[DesignObject]) -> str:
+    """Generate a simple technical sheet for clients."""
+    lines = ["Тех.лист для клиента:"]
+    for obj in objects:
+        lines.append(f"- {obj.id}: {obj.width}×{obj.height} ({obj.type})")
+    return "\n".join(lines)
+
+
+def generate_workshop_sheet(objects: List[DesignObject]) -> str:
+    """Generate a technical sheet for workshop."""
+    lines = ["Тех.лист для цеха:", "ID\tТип\tШирина\tВысота"]
+    for obj in objects:
+        lines.append(f"{obj.id}\t{obj.type}\t{obj.width}\t{obj.height}")
+    return "\n".join(lines)

--- a/main
+++ b/main
@@ -1,8 +1,0 @@
-from datetime import datetime
-
-def get_current_time():
-    now = datetime.now()
-    return {"time": now.strftime("%H:%M:%S")}
-
-def greet_user(name):
-    return f"Привет, {name}! Рад тебя видеть."

--- a/main.py
+++ b/main.py
@@ -1,0 +1,29 @@
+from datetime import datetime
+from typing import Dict
+
+from design_processor import (
+    extract_dimensions,
+    generate_client_sheet,
+    generate_workshop_sheet,
+    verify_against_spec,
+)
+
+
+def get_current_time():
+    now = datetime.now()
+    return {"time": now.strftime("%H:%M:%S")}
+
+
+def greet_user(name):
+    return f"Привет, {name}! Рад тебя видеть."
+
+
+def create_tech_sheets(file_path: str, spec: Dict[str, Dict[str, float]]):
+    objects = extract_dimensions(file_path)
+    verify_against_spec(objects, spec)
+    client_sheet = generate_client_sheet(objects)
+    workshop_sheet = generate_workshop_sheet(objects)
+    return {
+        "client_sheet": client_sheet,
+        "workshop_sheet": workshop_sheet,
+    }

--- a/tests/data/sample.svg
+++ b/tests/data/sample.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="100">
+  <rect id="rect1" x="0" y="0" width="100" height="50" />
+  <rect id="rect2" x="100" y="50" width="40" height="40" />
+</svg>

--- a/tests/test_design_processor.py
+++ b/tests/test_design_processor.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+
+from design_processor import (
+    extract_dimensions,
+    verify_against_spec,
+    generate_client_sheet,
+    generate_workshop_sheet,
+)
+
+
+DATA = Path(__file__).parent / "data" / "sample.svg"
+
+
+def test_extract_dimensions():
+    objs = extract_dimensions(str(DATA))
+    ids = {o.id for o in objs}
+    assert {"rect1", "rect2"} <= ids
+    rect1 = next(o for o in objs if o.id == "rect1")
+    assert rect1.width == 100
+    assert rect1.height == 50
+
+
+def test_verify_against_spec():
+    objs = extract_dimensions(str(DATA))
+    spec = {
+        "rect1": {"width": 100, "height": 50},
+        "rect2": {"width": 40, "height": 40},
+    }
+    mismatches = verify_against_spec(objs, spec)
+    assert mismatches == []
+    spec_bad = {"rect1": {"width": 110}}
+    mismatches = verify_against_spec(objs, spec_bad)
+    assert mismatches and mismatches[0]["expected"] == 110
+
+
+def test_generate_sheets():
+    objs = extract_dimensions(str(DATA))
+    client = generate_client_sheet(objs)
+    workshop = generate_workshop_sheet(objs)
+    assert "rect1" in client
+    assert "rect2" in workshop
+from main import create_tech_sheets
+
+
+def test_create_tech_sheets():
+    spec = {"rect1": {"width": 100, "height": 50}}
+    result = create_tech_sheets(str(DATA), spec)
+    assert "client_sheet" in result and "workshop_sheet" in result
+    assert "rect1" in result["client_sheet"]


### PR DESCRIPTION
## Summary
- add `design_processor` module for extracting dimensions from SVG designs and generating client and workshop technical sheets
- expose new `create_tech_sheets` function in main module and agent spec
- include tests for dimension extraction, spec verification, and sheet generation

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5d6b8498483268b2200ae41aafa47